### PR TITLE
Remove `httpdns.huaweicloud.com`

### DIFF
--- a/AWAvenue-Ads-Rule.txt
+++ b/AWAvenue-Ads-Rule.txt
@@ -252,7 +252,6 @@
 ||hm.baidu.com^
 ||hmma.baidu.com^
 ||httpdns.bcelive.com^
-||httpdns.huaweicloud.com^
 ||httpdns.ocloud.oppomobile.com^
 ||httpdns.push.oppomobile.com^
 ||hugelog.fcbox.com^


### PR DESCRIPTION
`httpdns.huaweicloud.com` 为[华为DNS云解析服务](https://www.huaweicloud.com/product/dns.html)
与Dnspod的[移动解析 HTTPDNS](https://cloud.tencent.com/product/httpdns)产品类似
此域名并非直接用于广告推送，会用于部分金融产品的安全域名解析