### PR TITLE
Fix 欧加系-WLAN助理

### DIFF
--- a/AWAvenue-Ads-Rule.txt
+++ b/AWAvenue-Ads-Rule.txt
@@ -191,8 +191,6 @@
 ||collect.kugou.com^
 ||commdata.v.qq.com^
 ||config.chsmarttv.com^
-||conn-service-cn-04.allawntech.com^
-||conn-service-cn-05.allawntech.com^
 ||crashlytics.com^
 ||crashlyticsreports-pa.googleapis.com^
 ||csjplatform.com^


### PR DESCRIPTION
`conn-service-cn-**.allawntech.com`类域名用于网络质量测试，非广告类域名
