### PR TITLE
Remove `mdp-appconf-in.heytapdl.com`

### DIFF
--- a/AWAvenue-Ads-Rule.txt
+++ b/AWAvenue-Ads-Rule.txt
@@ -336,7 +336,6 @@
 ||mapi.m.jd.com^
 ||masdkv6.3g.qq.com^
 ||mazu.m.qq.com^
-||mdp-appconf-in.heytapdl.com^
 ||mdp-usertrace-cn.heytapmobi.com^
 ||metok.sys.miui.com^
 ||metrics.apple.com^


### PR DESCRIPTION
`mdp-appconf-in.heytapdl.com` 用于印度版ColorOS/氧OS应用性能策略下发
与国内版 `mdp-appconf-cn.heytapdownload.com` 功能一致
此域名主要用于自动配置应用保活策略、游戏性能参数