### PR TITLE
移除 `lf1-cdn-tos.bytegoofy.com`

### DIFF
--- a/rule/domain.txt
+++ b/rule/domain.txt
@@ -268,7 +268,6 @@ knicks.jd.com
 ks.pull.yximgs.com
 launcher.smart-tv.cn
 launcherimg.smart-tv.cn
-lf1-cdn-tos.bytegoofy.com
 lf3-ad-union-sdk.pglstatp-toutiao.com
 liveats-vod.video.ptqy.gitv.tv
 livemonitor.huan.tv


### PR DESCRIPTION
字节系部分正常业务（用户协议页面、抖音开放平台等）需要使用此域名