### PR TITLE
[WIP] Perf: optimize entries with domain suffix/keywords

### DIFF
--- a/rule/domain.txt
+++ b/rule/domain.txt
@@ -852,3 +852,15 @@ ytx-file.110route.cn
 zeus.ad.xiaomi.com
 zhihu-web-analytics.zhihu.com
 zxid-m.mobileservice.cn
+# TODO: move to their order
+1rtb.com
+a.market.xiaomi.com
+ad.gameley.com
+adintl.cn
+adwangmai.com
+data.hicloud.com
+log.aliyuncs.com
+ubixioe.com
+vlion.cn
+yfanads.com
+zhangyuyidong.cn

--- a/rule/domain_regex.txt
+++ b/rule/domain_regex.txt
@@ -1,16 +1,3 @@
-.*.1rtb.com
-.*.a.market.xiaomi.com
-.*.ad.gameley.com
-.*.ad.gameley.com
-.*.adintl.cn
-.*.adx.adwangmai.com
-.*.adx.adwangmai.com
-.*.data.hicloud.com
-.*.log.aliyuncs.com
-.*.ubixioe.com
-.*.vlion.cn
-.*.yfanads.com
-.*.zhangyuyidong.cn
 [a-zA-Z0-9.-]*-ad-[a-zA-Z0-9.-]*.byteimg.com
 [a-zA-Z0-9.-]*-ad.sm.cn
 [a-zA-Z0-9.-]*-ad.video.yximgs.com


### PR DESCRIPTION
I don't see any reason why those entries are in `domain_regex.txt`. They can be moved to a separate `domain_suffix.txt` instead (WIP).

------

Some other optimization thoughts:

We could introduce a new source file `domain_keywords.txt` that can store `-ad.sm.cn` (instead of `[a-zA-Z0-9.-]*-ad.sm.cn`), which can produce the following outputs:

- `DOMAIN-KEYWORD` for Surge/Mihomo/Clash Legacy/QuanX/Loon
- `/-umeng.com/`-like regex for AdGuardHome (Not applicable for uBlock Origin/AdGuard App)

Compared to `DOMAIN-REGEX` or `DOMAIN-WILDCARD`, `DOMAIN-KEYWORD` is optimal for Surge/Mihomo/Clash Legacy/QuanX/Loon to consume (as they can be compiled into an in-memory DFA, which is also what I did in my `SukkaW/Surge`).