### PR TITLE
使用更简洁的 dnsmasq 规则格式

### DIFF
--- a/script/Dnsmasq.py
+++ b/script/Dnsmasq.py
@@ -2,9 +2,7 @@
 def format_domain(List):
     domain = []
     for line in List:
-        domain_lines = f"address=/{line.strip()}/0.0.0.0"
-        domain.append(domain_lines)
-        domain_lines = f"address=/{line.strip()}/::"
+        domain_lines = f"address=/{line.strip()}/#"
         domain.append(domain_lines)
     return domain
 


### PR DESCRIPTION
`https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html`

> An address specified as '#' translates to the NULL address of 0.0.0.0 and its IPv6 equivalent of :: so --address=/example.com/# will return NULL addresses for example.com and its subdomains. This is partly syntactic sugar for --address=/example.com/0.0.0.0 and --address=/example.com/:: but is also more efficient than including both as separate configuration lines.
