### PR TITLE
恢复 sing-box 及 mihomo 二进制(binary)规则的支持

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.12
-        
+
     - name: Execute Python script
       run: |
         git clone "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}" -b build build
@@ -29,7 +29,25 @@ jobs:
         mkdir Filters
         cp -Rf AWAvenue-Ads-Rule-Adblock.txt AWAvenue-Ads-Rule.txt #历史遗留问题
         mv AWAvenue-Ads-Rule-* Filters/
-  
+
+    - name: build singbox srs
+      run: |
+        cd build/out/Filters
+        wget -O ./sing-box.tar.gz https://github.com/SagerNet/sing-box/releases/download/v1.12.3/sing-box-1.12.3-linux-amd64.tar.gz
+        tar -xzvf sing-box.tar.gz
+        chmod +x */sing-box
+        ./*/sing-box rule-set compile --output AWAvenue-Ads-Rule-Singbox.srs AWAvenue-Ads-Rule-Singbox.json
+        rm -rf *sing-box*
+
+    - name: build mihomo mrs
+      run: |
+            cd build/out/Filters
+            wget -O ./mihomo.gz https://github.com/MetaCubeX/mihomo/releases/download/v1.19.12/mihomo-linux-amd64-v1.19.12.gz
+            gzip -d mihomo.gz
+            chmod +x mihomo
+            ./mihomo convert-ruleset domain yaml AWAvenue-Ads-Rule-Clash.yaml AWAvenue-Ads-Rule-Clash.mrs
+            rm -rf *mihomo*
+
     - name: Git push
       run: |
         git clone "https://${{ github.actor }}:${{ secrets.TOKEN }}@github.com/${{ github.repository }}" push


### PR DESCRIPTION
**二进制(binary)格式**规则在 sing-box(.srs) 及 mihomo(.mrs) 上，是作为被官方推荐使用的，**加载更快、内存占用更低**的规则格式。因此已被不少[配置示例](https://gist.github.com/CHIZI-0618/c0ecff01aeaf5ae82de54020f6e6937b)/订阅直接使用。**该格式不因被视为过时的格式**，且为避免现有用户的订阅失效，建议继续以可选构建产物方式恢复生成。
```
撤销 f8fc942 更改并更新 sing-box 构建版本至 1.12.3 最新稳定版；
修正 sing-box mrs 命名为 sing-box srs 及添加显式目录以增强稳定性。
```